### PR TITLE
feat(cli): auto-collect AI agent config during attestation init

### DIFF
--- a/app/cli/pkg/action/attestation_init.go
+++ b/app/cli/pkg/action/attestation_init.go
@@ -300,11 +300,12 @@ func (action *AttestationInit) Run(ctx context.Context, opts *AttestationInitRun
 		return "", err
 	}
 
-	// Auto-collect PR/MR metadata if in PR/MR context
-	if err := action.c.AutoCollectPRMetadata(ctx, attestationID, discoveredRunner, casBackend); err != nil {
-		action.Logger.Warn().Err(err).Msg("failed to auto-collect PR/MR metadata")
-		// Don't fail the init - this is best-effort
-	}
+	// Register and run auto-discovery collectors
+	action.c.RegisterCollectors(
+		crafter.NewPRMetadataCollector(discoveredRunner),
+		crafter.NewAIAgentConfigCollector(),
+	)
+	action.c.RunCollectors(ctx, attestationID, casBackend)
 
 	// Evaluate attestation-level policies at init phase
 	attClient := pb.NewAttestationServiceClient(action.CPConnection)

--- a/internal/aiagentconfig/aiagentconfig.go
+++ b/internal/aiagentconfig/aiagentconfig.go
@@ -1,0 +1,74 @@
+//
+// Copyright 2026 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aiagentconfig
+
+const (
+	// EvidenceID is the identifier for the AI agent config evidence
+	EvidenceID = "CHAINLOOP_AI_AGENT_CONFIG"
+	// EvidenceSchemaURL is the URL to the JSON schema for AI agent config
+	EvidenceSchemaURL = "https://schemas.chainloop.dev/aiagentconfig/1.0/ai-agent-config.schema.json"
+)
+
+// Agent identifies the AI agent provider
+type Agent struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+}
+
+// GitContext holds optional git information at capture time
+type GitContext struct {
+	Repository string `json:"repository,omitempty"`
+	Branch     string `json:"branch,omitempty"`
+	CommitSHA  string `json:"commit_sha,omitempty"`
+}
+
+// ConfigFile represents a single discovered configuration file
+type ConfigFile struct {
+	Path          string `json:"path"`
+	SHA256        string `json:"sha256"`
+	Size          int64  `json:"size"`
+	Base64Content string `json:"base64_content"`
+}
+
+// Data is the payload inside the evidence envelope
+type Data struct {
+	SchemaVersion string       `json:"schema_version"`
+	Agent         Agent        `json:"agent"`
+	ConfigHash    string       `json:"config_hash"`
+	CapturedAt    string       `json:"captured_at"`
+	GitContext    *GitContext  `json:"git_context,omitempty"`
+	ConfigFiles   []ConfigFile `json:"config_files"`
+	// Future fields for richer analysis
+	Permissions any `json:"permissions,omitempty"`
+	MCPServers  any `json:"mcp_servers,omitempty"`
+	Subagents   any `json:"subagents,omitempty"`
+}
+
+// Evidence is the full envelope matching the custom evidence format
+type Evidence struct {
+	ID     string `json:"chainloop.material.evidence.id"`
+	Schema string `json:"schema"`
+	Data   Data   `json:"data"`
+}
+
+// NewEvidence creates a new Evidence instance with the standard envelope
+func NewEvidence(data Data) *Evidence {
+	return &Evidence{
+		ID:     EvidenceID,
+		Schema: EvidenceSchemaURL,
+		Data:   data,
+	}
+}

--- a/internal/aiagentconfig/builder.go
+++ b/internal/aiagentconfig/builder.go
@@ -1,0 +1,83 @@
+//
+// Copyright 2026 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aiagentconfig
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// BuildEvidence reads discovered files and constructs the evidence payload.
+// rootDir is the base directory, filePaths are relative to rootDir.
+// gitCtx may be nil if not in a git repository.
+func BuildEvidence(rootDir string, filePaths []string, gitCtx *GitContext) (*Evidence, error) {
+	configFiles := make([]ConfigFile, 0, len(filePaths))
+	hashes := make([]string, 0, len(filePaths))
+
+	for _, relPath := range filePaths {
+		absPath := filepath.Join(rootDir, relPath)
+
+		content, err := os.ReadFile(absPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", relPath, err)
+		}
+
+		info, err := os.Stat(absPath)
+		if err != nil {
+			return nil, fmt.Errorf("stat %s: %w", relPath, err)
+		}
+
+		hash := sha256.Sum256(content)
+		hexHash := hex.EncodeToString(hash[:])
+		hashes = append(hashes, hexHash)
+
+		configFiles = append(configFiles, ConfigFile{
+			Path:          relPath,
+			SHA256:        hexHash,
+			Size:          info.Size(),
+			Base64Content: base64.StdEncoding.EncodeToString(content),
+		})
+	}
+
+	data := Data{
+		SchemaVersion: "v1alpha",
+		Agent:         Agent{Name: "claude"},
+		ConfigHash:    computeCombinedHash(hashes),
+		CapturedAt:    time.Now().UTC().Format(time.RFC3339),
+		GitContext:    gitCtx,
+		ConfigFiles:   configFiles,
+	}
+
+	return NewEvidence(data), nil
+}
+
+// computeCombinedHash sorts individual hashes, concatenates them, and hashes the result.
+func computeCombinedHash(hashes []string) string {
+	sorted := make([]string, len(hashes))
+	copy(sorted, hashes)
+	sort.Strings(sorted)
+
+	combined := sha256.Sum256([]byte(strings.Join(sorted, "")))
+
+	return hex.EncodeToString(combined[:])
+}

--- a/internal/aiagentconfig/builder_test.go
+++ b/internal/aiagentconfig/builder_test.go
@@ -1,0 +1,117 @@
+//
+// Copyright 2026 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aiagentconfig
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildEvidence(t *testing.T) {
+	rootDir := t.TempDir()
+
+	// Create test files
+	file1Content := []byte("# Project Rules\nAlways use Go.")
+	file2Content := []byte(`{"allow": ["read"]}`)
+
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, "CLAUDE.md"), file1Content, 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(rootDir, ".claude"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, ".claude", "settings.json"), file2Content, 0o600))
+
+	gitCtx := &GitContext{
+		Repository: "https://github.com/org/repo",
+		CommitSHA:  "abc123",
+	}
+
+	evidence, err := BuildEvidence(rootDir, []string{"CLAUDE.md", ".claude/settings.json"}, gitCtx)
+	require.NoError(t, err)
+
+	// Verify envelope
+	assert.Equal(t, EvidenceID, evidence.ID)
+	assert.Equal(t, EvidenceSchemaURL, evidence.Schema)
+
+	// Verify data
+	assert.Equal(t, "v1alpha", evidence.Data.SchemaVersion)
+	assert.Equal(t, "claude", evidence.Data.Agent.Name)
+	assert.NotEmpty(t, evidence.Data.CapturedAt)
+	assert.NotEmpty(t, evidence.Data.ConfigHash)
+
+	// Verify git context
+	require.NotNil(t, evidence.Data.GitContext)
+	assert.Equal(t, "https://github.com/org/repo", evidence.Data.GitContext.Repository)
+	assert.Equal(t, "abc123", evidence.Data.GitContext.CommitSHA)
+
+	// Verify config files
+	require.Len(t, evidence.Data.ConfigFiles, 2)
+
+	cf1 := evidence.Data.ConfigFiles[0]
+	assert.Equal(t, "CLAUDE.md", cf1.Path)
+	assert.Equal(t, int64(len(file1Content)), cf1.Size)
+	hash1 := sha256.Sum256(file1Content)
+	assert.Equal(t, hex.EncodeToString(hash1[:]), cf1.SHA256)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(file1Content), cf1.Base64Content)
+
+	cf2 := evidence.Data.ConfigFiles[1]
+	assert.Equal(t, ".claude/settings.json", cf2.Path)
+	hash2 := sha256.Sum256(file2Content)
+	assert.Equal(t, hex.EncodeToString(hash2[:]), cf2.SHA256)
+
+	// Verify config hash is deterministic
+	hashes := []string{hex.EncodeToString(hash1[:]), hex.EncodeToString(hash2[:])}
+	sort.Strings(hashes)
+	combined := sha256.Sum256([]byte(strings.Join(hashes, "")))
+	assert.Equal(t, hex.EncodeToString(combined[:]), evidence.Data.ConfigHash)
+}
+
+func TestBuildEvidenceWithoutGitContext(t *testing.T) {
+	rootDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, "CLAUDE.md"), []byte("content"), 0o600))
+
+	evidence, err := BuildEvidence(rootDir, []string{"CLAUDE.md"}, nil)
+	require.NoError(t, err)
+
+	assert.Nil(t, evidence.Data.GitContext)
+	assert.Len(t, evidence.Data.ConfigFiles, 1)
+}
+
+func TestBuildEvidenceJSONFormat(t *testing.T) {
+	rootDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, "CLAUDE.md"), []byte("content"), 0o600))
+
+	evidence, err := BuildEvidence(rootDir, []string{"CLAUDE.md"}, nil)
+	require.NoError(t, err)
+
+	// Verify it marshals to valid JSON with the correct envelope field
+	jsonData, err := json.Marshal(evidence)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(jsonData, &raw))
+
+	assert.Equal(t, EvidenceID, raw["chainloop.material.evidence.id"])
+	assert.Equal(t, EvidenceSchemaURL, raw["schema"])
+	assert.NotNil(t, raw["data"])
+}

--- a/internal/aiagentconfig/discover.go
+++ b/internal/aiagentconfig/discover.go
@@ -1,0 +1,66 @@
+//
+// Copyright 2026 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aiagentconfig
+
+import (
+	"path/filepath"
+	"sort"
+)
+
+// claudePatterns are glob patterns for Claude agent configuration files,
+// evaluated relative to a root directory.
+var claudePatterns = []string{
+	"CLAUDE.md",
+	".claude/CLAUDE.md",
+	".claude/settings.json",
+	".mcp.json",
+	".claude/rules/*.md",
+	".claude/agents/*.md",
+	".claude/commands/*.md",
+	".claude/skills/*/SKILL.md",
+}
+
+// Discover searches rootDir for AI agent configuration files.
+// It only looks in rootDir and its subdirectories, never in parent directories.
+// Returns deduplicated relative paths sorted alphabetically.
+func Discover(rootDir string) ([]string, error) {
+	seen := make(map[string]struct{})
+	var results []string
+
+	for _, pattern := range claudePatterns {
+		absPattern := filepath.Join(rootDir, pattern)
+		matches, err := filepath.Glob(absPattern)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, match := range matches {
+			rel, err := filepath.Rel(rootDir, match)
+			if err != nil {
+				return nil, err
+			}
+
+			if _, ok := seen[rel]; !ok {
+				seen[rel] = struct{}{}
+				results = append(results, rel)
+			}
+		}
+	}
+
+	sort.Strings(results)
+
+	return results, nil
+}

--- a/internal/aiagentconfig/discover_test.go
+++ b/internal/aiagentconfig/discover_test.go
@@ -1,0 +1,127 @@
+//
+// Copyright 2026 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aiagentconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscover(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    []string
+		expected []string
+	}{
+		{
+			name:     "no config files",
+			files:    []string{"main.go", "README.md"},
+			expected: nil,
+		},
+		{
+			name:     "top-level CLAUDE.md only",
+			files:    []string{"CLAUDE.md"},
+			expected: []string{"CLAUDE.md"},
+		},
+		{
+			name: "all claude patterns",
+			files: []string{
+				"CLAUDE.md",
+				".claude/CLAUDE.md",
+				".claude/settings.json",
+				".mcp.json",
+				".claude/rules/coding.md",
+				".claude/rules/testing.md",
+				".claude/agents/reviewer.md",
+				".claude/commands/deploy.md",
+				".claude/skills/search/SKILL.md",
+			},
+			expected: []string{
+				".claude/CLAUDE.md",
+				".claude/agents/reviewer.md",
+				".claude/commands/deploy.md",
+				".claude/rules/coding.md",
+				".claude/rules/testing.md",
+				".claude/settings.json",
+				".claude/skills/search/SKILL.md",
+				".mcp.json",
+				"CLAUDE.md",
+			},
+		},
+		{
+			name: "non-matching files are ignored",
+			files: []string{
+				"CLAUDE.md",
+				".claude/rules/coding.md",
+				".claude/rules/coding.txt",   // wrong extension for rules pattern
+				".claude/other/something.md", // not in a known pattern
+				"some/nested/CLAUDE.md",      // nested too deep
+			},
+			expected: []string{
+				".claude/rules/coding.md",
+				"CLAUDE.md",
+			},
+		},
+		{
+			name: "results are sorted and deduplicated",
+			files: []string{
+				".mcp.json",
+				"CLAUDE.md",
+				".claude/settings.json",
+			},
+			expected: []string{
+				".claude/settings.json",
+				".mcp.json",
+				"CLAUDE.md",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootDir := t.TempDir()
+
+			for _, f := range tt.files {
+				absPath := filepath.Join(rootDir, f)
+				require.NoError(t, os.MkdirAll(filepath.Dir(absPath), 0o755))
+				require.NoError(t, os.WriteFile(absPath, []byte("test content"), 0o600))
+			}
+
+			results, err := Discover(rootDir)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, results)
+		})
+	}
+}
+
+func TestDiscoverNeverTraversesParent(t *testing.T) {
+	parentDir := t.TempDir()
+
+	// Create a CLAUDE.md in the parent
+	require.NoError(t, os.WriteFile(filepath.Join(parentDir, "CLAUDE.md"), []byte("parent"), 0o600))
+
+	// Create a subdirectory to search from
+	childDir := filepath.Join(parentDir, "subproject")
+	require.NoError(t, os.MkdirAll(childDir, 0o755))
+
+	results, err := Discover(childDir)
+	require.NoError(t, err)
+	assert.Empty(t, results, "should not find files in parent directory")
+}

--- a/pkg/attestation/crafter/collector.go
+++ b/pkg/attestation/crafter/collector.go
@@ -1,0 +1,32 @@
+//
+// Copyright 2026 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crafter
+
+import (
+	"context"
+
+	"github.com/chainloop-dev/chainloop/pkg/casclient"
+)
+
+// Collector auto-discovers and attaches evidence during attestation init.
+// Each collector runs best-effort: failures are logged but never fail the attestation.
+type Collector interface {
+	// ID returns a unique identifier for this collector (used in logs).
+	ID() string
+	// Collect discovers data and adds materials to the attestation.
+	// Returning nil means nothing was collected (no-op is expected).
+	Collect(ctx context.Context, crafter *Crafter, attestationID string, casBackend *casclient.CASBackend) error
+}

--- a/pkg/attestation/crafter/collector_aiagentconfig.go
+++ b/pkg/attestation/crafter/collector_aiagentconfig.go
@@ -1,0 +1,90 @@
+//
+// Copyright 2026 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crafter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/chainloop-dev/chainloop/internal/aiagentconfig"
+	"github.com/chainloop-dev/chainloop/pkg/casclient"
+)
+
+// AIAgentConfigCollector discovers AI agent configuration files and attaches them as evidence.
+type AIAgentConfigCollector struct{}
+
+// NewAIAgentConfigCollector creates a new AI agent config collector.
+func NewAIAgentConfigCollector() *AIAgentConfigCollector {
+	return &AIAgentConfigCollector{}
+}
+
+func (c *AIAgentConfigCollector) ID() string { return "ai-agent-config" }
+
+func (c *AIAgentConfigCollector) Collect(ctx context.Context, cr *Crafter, attestationID string, casBackend *casclient.CASBackend) error {
+	files, err := aiagentconfig.Discover(cr.WorkingDir())
+	if err != nil {
+		return fmt.Errorf("discovering AI agent config files: %w", err)
+	}
+
+	if len(files) == 0 {
+		cr.Logger.Debug().Msg("no AI agent config files found, skipping")
+		return nil
+	}
+
+	cr.Logger.Info().Int("files", len(files)).Msg("discovered AI agent config files")
+
+	var gitCtx *aiagentconfig.GitContext
+	if head := cr.CraftingState.GetAttestation().GetHead(); head != nil {
+		gitCtx = &aiagentconfig.GitContext{
+			CommitSHA: head.GetHash(),
+		}
+		if remotes := head.GetRemotes(); len(remotes) > 0 {
+			gitCtx.Repository = remotes[0].GetUrl()
+		}
+	}
+
+	evidence, err := aiagentconfig.BuildEvidence(cr.WorkingDir(), files, gitCtx)
+	if err != nil {
+		return fmt.Errorf("building AI agent config evidence: %w", err)
+	}
+
+	jsonData, err := json.Marshal(evidence)
+	if err != nil {
+		return fmt.Errorf("marshaling AI agent config: %w", err)
+	}
+
+	tmpFile, err := os.CreateTemp("", "ai-agent-config-*.json")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.Write(jsonData); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	tmpFile.Close()
+
+	if _, err := cr.AddMaterialContractFree(ctx, attestationID, "EVIDENCE", "ai-agent-config-claude", tmpFile.Name(), casBackend, nil); err != nil {
+		return fmt.Errorf("adding AI agent config material: %w", err)
+	}
+
+	cr.Logger.Info().Msg("successfully collected AI agent configuration evidence")
+
+	return nil
+}

--- a/pkg/attestation/crafter/collector_prmetadata.go
+++ b/pkg/attestation/crafter/collector_prmetadata.go
@@ -1,0 +1,91 @@
+//
+// Copyright 2026 The Chainloop Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crafter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
+	"github.com/chainloop-dev/chainloop/internal/prinfo"
+	"github.com/chainloop-dev/chainloop/pkg/casclient"
+)
+
+// PRMetadataCollector collects pull/merge request metadata from the CI environment.
+type PRMetadataCollector struct {
+	runner SupportedRunner
+}
+
+// NewPRMetadataCollector creates a collector that detects PR/MR context from the given runner.
+func NewPRMetadataCollector(runner SupportedRunner) *PRMetadataCollector {
+	return &PRMetadataCollector{runner: runner}
+}
+
+func (c *PRMetadataCollector) ID() string { return "pr-metadata" }
+
+func (c *PRMetadataCollector) Collect(ctx context.Context, cr *Crafter, attestationID string, casBackend *casclient.CASBackend) error {
+	isPR, metadata, err := DetectPRContext(c.runner)
+	if err != nil {
+		return fmt.Errorf("detecting PR/MR context: %w", err)
+	}
+
+	if !isPR {
+		cr.Logger.Debug().Msg("not in PR/MR context, skipping metadata collection")
+		return nil
+	}
+
+	cr.Logger.Info().Str("platform", metadata.Platform).Str("number", metadata.Number).Msg("detected PR/MR context")
+
+	evidenceData := prinfo.NewEvidence(prinfo.Data{
+		Platform:     metadata.Platform,
+		Type:         metadata.Type,
+		Number:       metadata.Number,
+		Title:        metadata.Title,
+		Description:  metadata.Description,
+		SourceBranch: metadata.SourceBranch,
+		TargetBranch: metadata.TargetBranch,
+		URL:          metadata.URL,
+		Author:       metadata.Author,
+	})
+
+	jsonData, err := json.Marshal(evidenceData)
+	if err != nil {
+		return fmt.Errorf("marshaling PR/MR metadata: %w", err)
+	}
+
+	materialName := fmt.Sprintf("pr-metadata-%s", metadata.Number)
+	tmpFile, err := os.CreateTemp("", fmt.Sprintf("%s.json", materialName))
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.Write(jsonData); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	tmpFile.Close()
+
+	if _, err := cr.AddMaterialContractFree(ctx, attestationID, schemaapi.CraftingSchema_Material_CHAINLOOP_PR_INFO.String(), materialName, tmpFile.Name(), casBackend, nil); err != nil {
+		return fmt.Errorf("adding PR/MR metadata material: %w", err)
+	}
+
+	cr.Logger.Info().Msg("successfully collected and attested PR/MR metadata")
+
+	return nil
+}

--- a/pkg/attestation/crafter/crafter.go
+++ b/pkg/attestation/crafter/crafter.go
@@ -17,7 +17,6 @@ package crafter
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -31,7 +30,6 @@ import (
 	v1 "github.com/chainloop-dev/chainloop/app/controlplane/api/controlplane/v1"
 	schemaapi "github.com/chainloop-dev/chainloop/app/controlplane/api/workflowcontract/v1"
 	"github.com/chainloop-dev/chainloop/internal/ociauth"
-	"github.com/chainloop-dev/chainloop/internal/prinfo"
 	api "github.com/chainloop-dev/chainloop/pkg/attestation/crafter/api/attestation/v1"
 	"github.com/chainloop-dev/chainloop/pkg/attestation/crafter/materials"
 	"github.com/chainloop-dev/chainloop/pkg/attestation/crafter/runners/commitverification"
@@ -76,6 +74,9 @@ type Crafter struct {
 
 	// noStrictValidation skips strict schema validation
 	noStrictValidation bool
+
+	// collectors are auto-discovery collectors that run during attestation init
+	collectors []Collector
 }
 
 type VersionedCraftingState struct {
@@ -125,6 +126,30 @@ func WithNoStrictValidation(noStrictValidation bool) NewOpt {
 	return func(c *Crafter) error {
 		c.noStrictValidation = noStrictValidation
 		return nil
+	}
+}
+
+// WorkingDir returns the working directory used for file discovery.
+func (c *Crafter) WorkingDir() string {
+	return c.workingDir
+}
+
+// RegisterCollectors appends collectors to be run during attestation init.
+func (c *Crafter) RegisterCollectors(collectors ...Collector) {
+	c.collectors = append(c.collectors, collectors...)
+}
+
+// RunCollectors executes all registered collectors best-effort.
+// Failures are logged but never propagated.
+func (c *Crafter) RunCollectors(ctx context.Context, attestationID string, casBackend *casclient.CASBackend) {
+	if err := c.LoadCraftingState(ctx, attestationID); err != nil {
+		c.Logger.Warn().Err(err).Msg("failed to reload crafting state before running collectors")
+	}
+
+	for _, collector := range c.collectors {
+		if err := collector.Collect(ctx, c, attestationID, casBackend); err != nil {
+			c.Logger.Warn().Err(err).Str("collector", collector.ID()).Msg("collector failed")
+		}
 	}
 }
 
@@ -498,73 +523,6 @@ func (c *Crafter) ResolveEnvVars(ctx context.Context, attestationID string) erro
 		return fmt.Errorf("failed to persist crafting state: %w", err)
 	}
 
-	return nil
-}
-
-// AutoCollectPRMetadata automatically collects PR/MR metadata if running in a PR/MR context
-func (c *Crafter) AutoCollectPRMetadata(ctx context.Context, attestationID string, runner SupportedRunner, casBackend *casclient.CASBackend) error {
-	if err := c.requireStateLoaded(); err != nil {
-		return fmt.Errorf("crafting state not loaded before inspecting PR/MR metadata: %w", err)
-	}
-
-	if err := c.LoadCraftingState(ctx, attestationID); err != nil {
-		c.Logger.Warn().Err(err).Msg("failed to reload crafting state")
-	}
-
-	// Detect if we're in a PR/MR context
-	isPR, metadata, err := DetectPRContext(runner)
-	if err != nil {
-		return fmt.Errorf("failed to detect PR/MR context: %w", err)
-	}
-
-	// If not in PR/MR context, nothing to do
-	if !isPR {
-		c.Logger.Debug().Msg("not in PR/MR context, skipping metadata collection")
-		return nil
-	}
-
-	c.Logger.Info().Str("platform", metadata.Platform).Str("number", metadata.Number).Msg("detected PR/MR context")
-
-	// Create the material
-	evidenceData := prinfo.NewEvidence(prinfo.Data{
-		Platform:     metadata.Platform,
-		Type:         metadata.Type,
-		Number:       metadata.Number,
-		Title:        metadata.Title,
-		Description:  metadata.Description,
-		SourceBranch: metadata.SourceBranch,
-		TargetBranch: metadata.TargetBranch,
-		URL:          metadata.URL,
-		Author:       metadata.Author,
-	})
-
-	// Marshal to JSON
-	jsonData, err := json.Marshal(evidenceData)
-	if err != nil {
-		return fmt.Errorf("failed to marshal PR/MR metadata: %w", err)
-	}
-
-	// Create a temporary file for the metadata
-	materialName := fmt.Sprintf("pr-metadata-%s", metadata.Number)
-	tmpFile, err := os.CreateTemp("", fmt.Sprintf("%s.json", materialName))
-	if err != nil {
-		return fmt.Errorf("failed to create temp file: %w", err)
-	}
-	defer os.Remove(tmpFile.Name())
-
-	// Write the JSON data to the temp file
-	if _, err := tmpFile.Write(jsonData); err != nil {
-		tmpFile.Close()
-		return fmt.Errorf("failed to write metadata to temp file: %w", err)
-	}
-	tmpFile.Close()
-
-	// Add the material using the crafter with explicit CHAINLOOP_PR_INFO type
-	if _, err := c.AddMaterialContractFree(ctx, attestationID, schemaapi.CraftingSchema_Material_CHAINLOOP_PR_INFO.String(), materialName, tmpFile.Name(), casBackend, nil); err != nil {
-		return fmt.Errorf("failed to add PR/MR metadata material: %w", err)
-	}
-
-	c.Logger.Info().Msg("successfully collected and attested PR/MR metadata")
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Introduce a `Collector` interface in the crafter package for pluggable auto-discovery of evidence during attestation init
- Refactor existing PR/MR metadata collection into a `PRMetadataCollector` implementing the new interface
- Add `AIAgentConfigCollector` that discovers Claude agent configuration files (CLAUDE.md, .claude/*, .mcp.json) in the working directory and attaches them as custom EVIDENCE material
- The evidence JSON follows the custom evidence envelope format with `v1alpha` schema version, containing file contents (base64), SHA-256 digests, git context, and a combined config hash for drift detection

Ref: PFM-4919