### PR TITLE
chore: upgrade Go to 1.26.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ make migration_lint         # Lint migration files
 
 ## Key Technologies
 
-- **Language**: Go 1.26.2
+- **Language**: Go 1.26.3
 - **API**: gRPC with HTTP/JSON gateway, Protocol Buffers with buf
 - **Database**: PostgreSQL with Ent ORM, Atlas for migrations
 - **Authentication**: OIDC, JWT tokens

--- a/app/artifact-cas/Dockerfile.goreleaser
+++ b/app/artifact-cas/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM golang:1.26.2@sha256:2a2b4b5791cea8ae09caecba7bad0bd9631def96e5fe362e4a5e67009fe4ae61 AS builder
+FROM golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b AS builder
 
 FROM scratch
 

--- a/app/cli/Dockerfile.goreleaser
+++ b/app/cli/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM golang:1.26.2@sha256:2a2b4b5791cea8ae09caecba7bad0bd9631def96e5fe362e4a5e67009fe4ae61 AS builder
+FROM golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b AS builder
 RUN mkdir -p /.config/chainloop
 
 FROM scratch

--- a/app/controlplane/Dockerfile.goreleaser
+++ b/app/controlplane/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM golang:1.26.2@sha256:2a2b4b5791cea8ae09caecba7bad0bd9631def96e5fe362e4a5e67009fe4ae61 AS builder
+FROM golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b AS builder
 
 FROM scratch
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chainloop-dev/chainloop
 
-go 1.26.2
+go 1.26.3
 
 require (
 	cloud.google.com/go/secretmanager v1.16.0


### PR DESCRIPTION
## Summary

Upgrades Go from 1.26.2 to 1.26.3 to pick up the latest patch-level fixes.

Touchpoints:
- `go.mod` `go` directive
- `goreleaser` Dockerfiles for control-plane, CLI, and artifact-cas (image tag and pinned SHA256 digest)
- `CLAUDE.md` Key Technologies section

CI workflows already source the Go version from `go.mod` (`go-version-file: 'go.mod'`), so no workflow edits are required. Per project policy, `extras/dagger/go.mod` is intentionally left unchanged.

## AI disclosure

This PR was prepared with assistance from Claude Code. Affected commits include the `Assisted-by: Claude Code` trailer.